### PR TITLE
Add the possibility to run without visual odometry

### DIFF
--- a/config/hexa_control_odomless.yaml
+++ b/config/hexa_control_odomless.yaml
@@ -1,0 +1,8 @@
+# Serial
+SerialPort: /dev/ttyACM0
+
+# Baudrate: 1 - 1000000, 16 - 115200, 34 - 57600
+SerialBaudrate: 1
+
+# Odometry Topic
+OdomEnable: false

--- a/include/hexa_control/robotHexa.hpp
+++ b/include/hexa_control/robotHexa.hpp
@@ -135,6 +135,10 @@ public:
   // void send_ros_stop(int nbrun,int nbtrans);
   //void posCallback(const rgbdslam::XtionDisplacement& msg);
   void posCallback(const nav_msgs::Odometry& msg);
+  /// Give the distance covered by the robot using the given controller.
+  /// The actual data is available only after the transfer methd has finished.
+  /// Also, if the visual odometry was disabled, the return value will invariably
+  /// be -1.
   float covered_distance()
   {
     return _covered_distance;
@@ -180,8 +184,10 @@ protected:
   ros::Subscriber _sub;
   ros::Publisher _reset_filter_pub;
 
-  std::string _serial_port, _odom;
+  // Store the values of parameters for this ROS node
+  std::string _serial_port, _odom_topic_name;
   int _serial_baudrate, _baudrate_choice;
+  bool _odom_enable;
 };
 
 #endif

--- a/include/hexa_control/robotHexa.hpp
+++ b/include/hexa_control/robotHexa.hpp
@@ -154,6 +154,7 @@ protected:
   void _read_contacts();
   dynamixel::Usb2Dynamixel _controller;
   float _covered_distance;
+  bool _odom_message_received;
 
 #ifdef IMU
   imu::Usb2Imu _imu;

--- a/src/robotHexa.cpp
+++ b/src/robotHexa.cpp
@@ -7,11 +7,9 @@
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
 #include <hexa_control/robotHexa.hpp>
 
-bool msg_recv;
-
 /*void RobotHexa :: posCallback(const rgbdslam::XtionDisplacement& msg)
   {
-  msg_recv=true;
+  _odom_message_received=true;
 
   ROS_INFO("Commandes recues: \nX:%f \n Y:%f \n Z:%f \n duraction: %f  ",msg.x,msg.y,msg.z,msg.duration);
   _covered_distance=round(msg.x * 100) / 100.0f;
@@ -39,7 +37,7 @@ void RobotHexa :: posCallback(const nav_msgs::Odometry& msg)
   if(tdiff <= ros::Duration(0,0))// responce received after end of movement.
   {
     ROS_DEBUG_STREAM("odometry message after end of movement; processing");
-    msg_recv = true;
+    _odom_message_received = true;
   }
   else
   {
@@ -734,8 +732,8 @@ void RobotHexa :: initRosNode(  int argc ,char** argv,boost::shared_ptr<ros::Nod
 void RobotHexa:: getSlamInfo()
 {
   this->_request_time=ros::Time::now();
-  msg_recv=false;
-  while(msg_recv ==false)
+  _odom_message_received=false;
+  while(_odom_message_received ==false)
     ros::spinOnce();
 
 }


### PR DESCRIPTION
This would enable us to make demos with pre-recorded controllers without the need for the unstable visual odometry.
