### PR TITLE
enable again the reset

### DIFF
--- a/src/hexapod_server.cpp
+++ b/src/hexapod_server.cpp
@@ -17,7 +17,7 @@ bool transfert(hexa_control::Transfert::Request  &req,
   try
   {
     ROS_INFO_STREAM("Requested motion duration : " << req.duration);
-    if(req.duration < -1)
+    else if(req.duration <= -2)
     {
       hexapod_p->relax();
       return true;

--- a/src/hexapod_server.cpp
+++ b/src/hexapod_server.cpp
@@ -17,7 +17,7 @@ bool transfert(hexa_control::Transfert::Request  &req,
   try
   {
     ROS_INFO_STREAM("Requested motion duration : " << req.duration);
-    else if(req.duration <= -2)
+    if(req.duration <= -2)
     {
       hexapod_p->relax();
       return true;


### PR DESCRIPTION
The reset method used to bring the hexapod up in a cleaner version than we had recently. This behavior has been restored and adapted for our version of Pexod.

Tested on the actual robot
